### PR TITLE
chore: upgrade golangci-lint to v2.12.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ ENVTEST_K8S_VERSION ?= $(shell v='$(call gomodver,k8s.io/api)'; \
   [ -n "$$v" ] || { echo "Set ENVTEST_K8S_VERSION manually (k8s.io/api replace has no tag)" >&2; exit 1; }; \
   printf '%s\n' "$$v" | sed -E 's/^v?[0-9]+\.([0-9]+).*/1.\1/')
 
-GOLANGCI_LINT_VERSION ?= v2.11.4
+GOLANGCI_LINT_VERSION ?= v2.12.1
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.


### PR DESCRIPTION
Upgrade golangci-lint from v2.11.4 to v2.12.1.

No lint issues found after upgrade.