### PR TITLE
fix: replace POSIX-incompatible [[ with [ in observability test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ cover.out
 # helm charts
 # helm package directory
 target
+.worktree/

--- a/test/e2e/smoke/observability/chainsaw-test.yaml
+++ b/test/e2e/smoke/observability/chainsaw-test.yaml
@@ -58,7 +58,7 @@ spec:
 
               # Test metrics endpoint accessibility
               HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:9102/metrics)
-              if [[ "$HTTP_CODE" != "200" ]]; then
+              if [ "$HTTP_CODE" != "200" ]; then
                 echo "ERROR: Failed to access metrics endpoint, HTTP code: $HTTP_CODE"
                 kill $PF_PID 2>/dev/null || true
                 exit 1


### PR DESCRIPTION
Chainsaw test scripts may run in `/bin/sh` which does not support `[[` (a bash-ism).

Replace `[[ ...` with POSIX-compatible `[ ...` in:
- `test/e2e/smoke/observability/chainsaw-test.yaml`

Same fix pattern applied across other operators (zookeeper #356, trino #370, kafka #277, secret #355, commons #288).