### PR TITLE
fix: add superset 4.1.2 to CI product-version matrix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,7 +70,7 @@ jobs:
           '1.34.3',
           '1.35.0'
         ]
-        product-version: ['4.0.2', '4.1.1']
+        product-version: ['4.0.2', '4.1.1', '4.1.2']
     steps:
       - name: Clone the code
         uses: actions/checkout@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           # '1.34.3',
           '1.35.0'
         ]
-        product-version: ['4.0.2', '4.1.1']
+        product-version: ['4.0.2', '4.1.1', '4.1.2']
     steps:
       - name: Clone the code
         uses: actions/checkout@v6


### PR DESCRIPTION
Align product-version matrix with available container images.

Available images in `quay.io/zncdatadev/superset` with `kubedoop0.4.0`:
- `4.0.2-kubedoop0.4.0` ✅
- `4.1.1-kubedoop0.4.0` ✅
- `4.1.2-kubedoop0.4.0` ✅ (missing from CI matrix)

Updated in:
- `.github/workflows/release.yml` — release chainsaw-e2e matrix
- `.github/workflows/test.yml` — PR/push chainsaw-e2e matrix