### PR TITLE
fix(e2e): wire PRODUCT_VERSION into chainsaw values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ cover.out
 # helm package directory
 target
 .worktree/
+
+# generated chainsaw values
+test/e2e/.values.yaml

--- a/Makefile
+++ b/Makefile
@@ -294,6 +294,10 @@ CHAINSAW ?= $(LOCALBIN)/chainsaw
 CHAINSAW_VERSION ?= v0.2.13
 CHAINSAW_CLUSTER ?= chainsaw-${PROJECT_NAME}
 CHAINSAW_KUBECONFIG ?= .kubeconfig
+# Chainsaw only resolves ($values.*) bindings from files passed via --values,
+# so the product version selected by the CI matrix must be written to a values
+# file before running the tests. See the chainsaw-values target.
+CHAINSAW_VALUES ?= test/e2e/.values.yaml
 # KIND_K8S_VERSION refers to the version of Kubernetes to be used by kind node image.
 # The version only effects e2e tests.
 # When run `kind create --image kindest/node:v${KIND_K8S_VERSION}`, the node image version of k8s will be used to create the kind cluster,
@@ -339,9 +343,13 @@ setup-chainsaw-e2e: chainsaw docker-build ## Run the chainsaw setup
 	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(MAKE) deploy
 
 
+.PHONY: chainsaw-values
+chainsaw-values: ## Generate the chainsaw values file from PRODUCT_VERSION. When unset, null lets the operator default apply.
+	@echo "product_version: $${PRODUCT_VERSION:-null}" > $(CHAINSAW_VALUES)
+
 .PHONY: chainsaw-e2e
-chainsaw-e2e: ## Run the chainsaw e2e tests
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+chainsaw-e2e: chainsaw-values ## Run the chainsaw e2e tests
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)
 
 .PHONY: cleanup-chainsaw-e2e
 cleanup-chainsaw-e2e: ## Run the chainsaw cleanup
@@ -358,9 +366,9 @@ cleanup-chainsaw-cluster: ## Tear down the Kind cluster used for chainsaw e2e te
 	rm -f $(CHAINSAW_KUBECONFIG)
 
 .PHONY: chart-e2e
-chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package ## Run e2e tests with Helm chart deployment
+chart-e2e: setup-chainsaw-cluster chainsaw docker-build helm-chart-package chainsaw-values ## Run e2e tests with Helm chart deployment
 	"$(KIND)" --name $(CHAINSAW_CLUSTER) load docker-image "$(IMG)"
 	"$(HELM)" upgrade --install --create-namespace --namespace superset-operator \
 		--kubeconfig $(CHAINSAW_KUBECONFIG) --wait $(PROJECT_NAME) \
 		target/charts/$(PROJECT_NAME)-$(VERSION).tgz
-	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/
+	KUBECONFIG=$(CHAINSAW_KUBECONFIG) $(CHAINSAW) test --config ./test/e2e/.chainsaw.yaml --test-dir ./test/e2e/ --values $(CHAINSAW_VALUES)


### PR DESCRIPTION
## Problem

The chainsaw e2e product-version matrix is dead. CI (`test.yml` / `release.yml`) sets a `PRODUCT_VERSION` env var per matrix leg, and the chainsaw tests reference `($values.product_version)` in CR manifests (e.g. `spec.image.productVersion`). But chainsaw only populates `$values` from `--values` files, and the `chainsaw-e2e` Makefile target never passed one. As a result `($values.product_version)` always resolved to `null`, `productVersion` serialized unset, and every matrix leg silently tested the operator's `DefaultProductVersion` from `api/v1alpha1/image.go`.

## Fix

- Add a `chainsaw-values` target that generates `test/e2e/.values.yaml` from `$PRODUCT_VERSION`. When the variable is unset it writes `product_version: null`, which preserves the previous fallback to the operator default for local runs.
- Pass `--values test/e2e/.values.yaml` in `chainsaw-e2e` (and in `chart-e2e` where present, so both chainsaw invocations resolve values consistently).
- Gitignore the generated file.

## Verification

Verified locally on zookeeper-operator against a kind cluster: generated the values file via `make chainsaw-values` with `PRODUCT_VERSION=3.9.3` and ran the `smoke/cluster-operation` chainsaw case with `--values test/e2e/.values.yaml` (the exact flags the patched target uses). The case passed (1 passed / 0 failed / 0 skipped), and the applied `ZookeeperCluster` CR carried `spec.image.productVersion: "3.9.3"` explicitly — the field has no CRD default, so its presence proves the values wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
